### PR TITLE
feat: builder update

### DIFF
--- a/cmd/controller/app/job/builder.go
+++ b/cmd/controller/app/job/builder.go
@@ -67,6 +67,7 @@ func NewJobBuilder(dbService database.DBService, jobParams config.JobParams) *Jo
 		roleCode:          make(map[string][]byte),
 		groupAssociations: make(map[string][]map[string]string),
 		datasets:          make(map[string]map[string][]openapi.DatasetInfo),
+		channels:          make(map[string]openapi.Channel),
 	}
 }
 
@@ -140,14 +141,14 @@ func (b *JobBuilder) setup() error {
 	b.roleCode = zippedRoleCode
 
 	// Iterating for each dataset id to fetch dataset info and update the datasets array.
-	for roleName, trainerGrups := range b.jobSpec.DataSpec.FromSystem {
-		if len(trainerGrups) == 0 {
+	for roleName, groups := range b.jobSpec.DataSpec.FromSystem {
+		if len(groups) == 0 {
 			return fmt.Errorf("no dataset group specified for trainer role %s", roleName)
 		}
 
 		b.datasets[roleName] = make(map[string][]openapi.DatasetInfo)
 
-		for groupName, datasetIds := range trainerGrups {
+		for groupName, datasetIds := range groups {
 			if len(datasetIds) == 0 {
 				return fmt.Errorf("no dataset specified for trainer role %s, group %s", roleName, groupName)
 			}

--- a/examples/asyncfl_hier_mnist/job.json
+++ b/examples/asyncfl_hier_mnist/job.json
@@ -6,12 +6,18 @@
         "fromUser": {
             "default": 0
         },
-        "fromSystem": [
-            "624b4417dad565fc66f8a0ee",
-            "624b4428dad565fc66f8a0ef",
-            "624b4430dad565fc66f8a0f0",
-            "624b4437dad565fc66f8a0f1"
-        ]
+        "fromSystem": {
+            "trainer": {
+                "eu": [
+                    "640f9c9c62b4c80cab55a949",
+                    "640f9ca262b4c80cab55a94a"
+                ],
+                "na": [
+                    "640f9caa62b4c80cab55a94b",
+                    "640f9caf62b4c80cab55a94c"
+                ]
+            }
+        }
     },
     "priority": "low",
     "backend": "mqtt",

--- a/examples/asyncfl_hier_mnist/schema.json
+++ b/examples/asyncfl_hier_mnist/schema.json
@@ -1,93 +1,93 @@
 {
-	"name": "A simple hierarchical FL MNIST example schema",
-	"description": "a sample schema to demostrate the hierarchical FL setting",
-	"roles": [
-		{
-			"name": "trainer",
-			"description": "It consumes the data and trains local model",
-			"isDataConsumer": true,
-			"groupAssociation": [
-				{
-					"param-channel": "default/eu"
-				},
-				{
-					"param-channel": "default/na"
-				}
-			]
-		},
-		{
-			"name": "middle-aggregator",
-			"description": "It aggregates the updates from trainers",
-			"groupAssociation": [
-				{
-					"param-channel": "default/eu",
-					"global-channel": "default"
-				},
-				{
-					"param-channel": "default/na",
-					"global-channel": "default"
-				}
-			]
-		},
-		{
-			"name": "top-aggregator",
-			"description": "It aggregates the updates from middle-aggregator",
-			"groupAssociation": [
-				{
-					"global-channel": "default"
-				}
-			]
-		}
-	],
-	"channels": [
-		{
-			"name": "param-channel",
-			"description": "Model update is sent from trainer to middle-aggregator and vice-versa",
-			"pair": [
-				"trainer",
-				"middle-aggregator"
-			],
-			"groupBy": {
-				"type": "tag",
-				"value": [
-					"default/eu",
-					"default/na"
-				]
-			},
-			"funcTags": {
-				"trainer": [
-					"fetch",
-					"upload"
-				],
-				"middle-aggregator": [
-					"distribute",
-					"aggregate"
-				]
-			}
-		},
-		{
-			"name": "global-channel",
-			"description": "Model update is sent from middle-aggregator to top-aggregator and vice-versa",
-			"pair": [
-				"top-aggregator",
-				"middle-aggregator"
-			],
-			"groupBy": {
-				"type": "tag",
-				"value": [
-					"default"
-				]
-			},
-			"funcTags": {
-				"top-aggregator": [
-					"distribute",
-					"aggregate"
-				],
-				"middle-aggregator": [
-					"fetch",
-					"upload"
-				]
-			}
-		}
-	]
+    "name": "A simple hierarchical FL MNIST example schema",
+    "description": "a sample schema to demostrate the hierarchical FL setting",
+    "roles": [
+        {
+            "name": "trainer",
+            "description": "It consumes the data and trains local model",
+            "isDataConsumer": true,
+            "groupAssociation": [
+                {
+                    "param-channel": "eu"
+                },
+                {
+                    "param-channel": "na"
+                }
+            ]
+        },
+        {
+            "name": "middle-aggregator",
+            "description": "It aggregates the updates from trainers",
+            "groupAssociation": [
+                {
+                    "param-channel": "eu",
+                    "global-channel": "default"
+                },
+                {
+                    "param-channel": "na",
+                    "global-channel": "default"
+                }
+            ]
+        },
+        {
+            "name": "top-aggregator",
+            "description": "It aggregates the updates from middle-aggregator",
+            "groupAssociation": [
+                {
+                    "global-channel": "default"
+                }
+            ]
+        }
+    ],
+    "channels": [
+        {
+            "name": "param-channel",
+            "description": "Model update is sent from trainer to middle-aggregator and vice-versa",
+            "pair": [
+                "trainer",
+                "middle-aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "eu",
+                    "na"
+                ]
+            },
+            "funcTags": {
+                "trainer": [
+                    "fetch",
+                    "upload"
+                ],
+                "middle-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ]
+            }
+        },
+        {
+            "name": "global-channel",
+            "description": "Model update is sent from middle-aggregator to top-aggregator and vice-versa",
+            "pair": [
+                "top-aggregator",
+                "middle-aggregator"
+            ],
+            "groupBy": {
+                "type": "tag",
+                "value": [
+                    "default"
+                ]
+            },
+            "funcTags": {
+                "top-aggregator": [
+                    "distribute",
+                    "aggregate"
+                ],
+                "middle-aggregator": [
+                    "fetch",
+                    "upload"
+                ]
+            }
+        }
+    ]
 }


### PR DESCRIPTION
one of builder's internal map variables was not initialized, which made the controller fail to create tasks out of job silently while only returning 500 error to flamectl.

Also, to test the builder code, the asyncfl_hier_mnist example was updated accordingly. It was confirmed that the controller created the configs for the example correctly.